### PR TITLE
Updates to make libcluster_gae work on App Engine projects with Zonal…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog for v0.2
+
+## v0.2.0 (2024-02-26)
+
+### Enhancements
+
+  * Support for Google Cloud [projects created after September 6th, 2018](https://cloud.google.com/compute/docs/networking/zonal-dns)
+  * `cluster_across_versions` option allows you to disable the default setting that different versions of the same service cluster together.
+
+### Deprecation
+
+  * Google Cloud projects created before September 6th, 2018 use Global DNS, and not Zonal DNS. For these projects, continue using v0.1
+  * Similarly, old projects still using Distillary will need to use the old README.

--- a/lib/google_app_engine.ex
+++ b/lib/google_app_engine.ex
@@ -16,7 +16,8 @@ defmodule Cluster.Strategy.GoogleAppEngine do
       my_app: [
         strategy: Cluster.Strategy.GoogleAppEngine,
         config: [
-          polling_interval: 10_000
+          polling_interval: 10_000,
+          cluster_across_versions: false
         ]
       ]
     ]
@@ -27,6 +28,7 @@ defmodule Cluster.Strategy.GoogleAppEngine do
   Options can be set for the strategy under the `:config` key when defining the topology.
 
   * `:polling_interval` - Interval for checking for the list of running instances. Defaults to `10_000`
+  * `:cluster_across_versions` - Boolean if you'd like to cluster different versions of the same service together. Defaults to `true`
 
   ## Application Setup
 
@@ -36,15 +38,28 @@ defmodule Cluster.Strategy.GoogleAppEngine do
 
   ### Release Configuration
 
-  Update your release's `vm.args` file to include the following lines.
+  Add the following to, or create a `rel/env.sh.eex`
 
-  ```
-  ## Name of the node
-  -name <%= release_name%>@${GAE_INSTANCE}.c.${GOOGLE_CLOUD_PROJECT}.internal
+  ```bash
+  #!/bin/sh
 
-  ## Limit distributed erlang ports to a single port
-  -kernel inet_dist_listen_min 9999
-  -kernel inet_dist_listen_max 9999
+
+  if [ ! -f /tmp/zone ]; then
+  curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token | jq -r .access_token > /tmp/access_token
+  curl -H "Authorization: Bearer $(cat /tmp/access_token)" https://appengine.googleapis.com/v1/apps/${GOOGLE_CLOUD_PROJECT}/services/${GAE_SERVICE}/versions/${GAE_VERSION}/instances/${GAE_INSTANCE} | jq -r .vmZoneName > /tmp/zone
+  fi
+
+  export RELEASE_DISTRIBUTION="name"
+  export RELEASE_NODE="${REL_NAME}@${GAE_INSTANCE}.$(cat /tmp/zone).c.${GOOGLE_CLOUD_PROJECT}.internal"
+
+  case $RELEASE_COMMAND in
+  start*|daemon*)
+    ELIXIR_ERL_OPTIONS="-kernel inet_dist_listen_min 9999 inet_dist_listen_max 9999"
+    export ELIXIR_ERL_OPTIONS
+    ;;
+  *)
+    ;;
+  esac
   ```
 
   ### GAE Configuration File
@@ -64,13 +79,16 @@ defmodule Cluster.Strategy.GoogleAppEngine do
   ```
   """
 
+  require Logger
+
   use GenServer
   use Cluster.Strategy
 
   alias Cluster.Strategy.State
 
   @default_polling_interval 10_000
-  @access_token_path 'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token'
+  @default_cluster_across_versions true
+  @access_token_path ~c"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args)
@@ -101,39 +119,53 @@ defmodule Cluster.Strategy.GoogleAppEngine do
 
     nodes = get_nodes(state)
 
-    Cluster.Strategy.connect_nodes(topology, connect, list_nodes, nodes)
+    case Cluster.Strategy.connect_nodes(topology, connect, list_nodes, nodes) do
+      :ok ->
+        Logger.debug("Connected to nodes #{inspect(nodes)}")
+
+      {:error, e} ->
+        Logger.error("Failed connecting with #{inspect(e)}")
+    end
 
     Process.send_after(self(), :load, polling_interval(state))
 
     state
   end
 
-  defp polling_interval(%State{config: config}) do
-    Keyword.get(config, :polling_interval, @default_polling_interval)
-  end
+  defp polling_interval(%State{config: config}),
+    do: Keyword.get(config, :polling_interval, @default_polling_interval)
 
-  defp get_nodes(%State{}) do
+  defp cluster_across_versions(%State{config: config}),
+    do: Keyword.get(config, :cluster_across_versions, @default_cluster_across_versions)
+
+  defp get_nodes(state = %State{}) do
     project_id = System.get_env("GOOGLE_CLOUD_PROJECT")
-    instances = get_running_instances(project_id)
+    instances = get_running_instances(project_id, state)
 
     release_name = System.get_env("REL_NAME")
 
-    Enum.map(instances, & :"#{release_name}@#{&1}.c.#{project_id}.internal")
+    Enum.map(instances, fn {id, zone} ->
+      :"#{release_name}@#{id}.#{zone}.c.#{project_id}.internal"
+    end)
   end
 
-  defp get_running_instances(project_id) do
+  defp get_running_instances(project_id, state = %State{}) do
     service_id = System.get_env("GAE_SERVICE")
 
-    versions = get_running_versions(project_id, service_id)
-
-    Enum.flat_map(versions, &get_instances_for_version(project_id, service_id, &1))
+    if cluster_across_versions(state) do
+      versions = get_running_versions(project_id, service_id)
+      Enum.flat_map(versions, &get_instances_for_version(project_id, service_id, &1))
+    else
+      version = System.get_env("GAE_VERSION")
+      get_instances_for_version(project_id, service_id, version)
+    end
   end
 
   defp get_running_versions(project_id, service_id) do
     access_token = access_token()
-    headers = [{'Authorization', 'Bearer #{access_token}'}]
+    headers = [{~c"Authorization", ~c"Bearer #{access_token}"}]
 
-    api_url = 'https://appengine.googleapis.com/v1/apps/#{project_id}/services/#{service_id}'
+    api_url = ~c"https://appengine.googleapis.com/v1/apps/#{project_id}/services/#{service_id}"
 
     case :httpc.request(:get, {api_url, headers}, [], []) do
       {:ok, {{_, 200, _}, _headers, body}} ->
@@ -144,9 +176,10 @@ defmodule Cluster.Strategy.GoogleAppEngine do
 
   defp get_instances_for_version(project_id, service_id, version) do
     access_token = access_token()
-    headers = [{'Authorization', 'Bearer #{access_token}'}]
+    headers = [{~c"Authorization", ~c"Bearer #{access_token}"}]
 
-    api_url = 'https://appengine.googleapis.com/v1/apps/#{project_id}/services/#{service_id}/versions/#{version}/instances'
+    api_url =
+      ~c"https://appengine.googleapis.com/v1/apps/#{project_id}/services/#{service_id}/versions/#{version}/instances"
 
     case :httpc.request(:get, {api_url, headers}, [], []) do
       {:ok, {{_, 200, _}, _headers, body}} ->
@@ -156,19 +189,23 @@ defmodule Cluster.Strategy.GoogleAppEngine do
 
   defp handle_instances(%{"instances" => instances}) do
     instances
-    |> Enum.filter(& &1["vmStatus"] == "RUNNING")
-    |> Enum.map(& &1["id"])
+    |> Enum.filter(&(&1["vmStatus"] == "RUNNING"))
+    |> Enum.map(&{&1["id"], &1["vmZoneName"]})
   end
 
   defp handle_instances(_), do: []
 
   defp access_token do
-    headers = [{'Metadata-Flavor', 'Google'}]
+    headers = [{~c"Metadata-Flavor", ~c"Google"}]
 
     case :httpc.request(:get, {@access_token_path, headers}, [], []) do
       {:ok, {{_, 200, _}, _headers, body}} ->
         %{"access_token" => token} = Jason.decode!(body)
         token
+
+      error ->
+        Logger.error("Token error #{inspect(error)}")
+        nil
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule LibclusterGae.MixProject do
     [
       app: :libcluster_gae,
       description: "",
-      version: "0.1.2",
+      version: "0.2.0",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -34,6 +34,7 @@ defmodule LibclusterGae.MixProject do
       links: %{"GitHub" => source_url()}
     ]
   end
+
   # Run "mix help compile.app" to learn about applications.
   def application do
     [


### PR DESCRIPTION
… DNS since Global DNS has been deprecated.

This resolves #1.

1. With Mix Releases, move from `vm.args` into `env.sh.eex`
2. The biggest issue we need to work around is there is no environment variable telling us which zone our instance resides in, and we need this to name our node when it starts. The workaround is to make an App Engine Admin API call and capture that zone in order to set the node name. See `env.sh.eex`.
3. Changes to the actual strategy are minimal - the call to list all running instances needed to be enhanced to grab the `vmZoneName` since it is required to generate the FQDN of our instances. I know #1 mentions the API didn't return this value, but I found that it does - maybe it was fixed in the past 4 or 5 years 😄 .

Anyway, this was a fun one to debug. Let me know if you have any questions.